### PR TITLE
This commit refactors the crate to decouple it from diesel_async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 rust-version = "1.67"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,14 @@ thiserror = "1"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 async-trait = "0.1"
 futures = "0.3"
-diesel = { version = "2.1", features = ["postgres", "serde_json", "chrono", "uuid"] }
+diesel = { version = "2.1", features = ["serde_json", "chrono", "uuid"] }
 diesel-derive-newtype = "2.0.0-rc.0"
-diesel-async = { version = "0.3", features = ["postgres", "bb8"] }
-tokio = { version = "1.25", features = ["rt", "time", "macros"] }
+diesel-async = { version = "0.3", features = ["postgres", "bb8"], optional = true }
+tokio = { version = "1.25", features = ["rt", "time", "macros", "sync"] }
 
 [dev-dependencies]
 itertools = "0.10"
+
+[features]
+default = ["async_postgres"]
+async_postgres = ["diesel-async"]

--- a/examples/simple_worker/Cargo.toml
+++ b/examples/simple_worker/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-backie = { path = "../../" }
+backie = { path = "../../", features = ["async_postgres"] }
 anyhow = "1"
 env_logger = "0.10"
 log = "0.4.0"
 tokio = { version = "1", features = ["full"] }
-diesel-async = { version = "0.2", features = ["postgres", "bb8"] }
-diesel = { version = "2.0", features = ["postgres"] }
+diesel-async = { version = "0.3", features = ["postgres", "bb8"] }
+diesel = { version = "2.1", features = ["postgres"] }
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use thiserror::Error;
 
 /// Library errors
@@ -29,4 +31,7 @@ pub enum AsyncQueueError {
 
     #[error("Task with name {0} is not serializable to JSON")]
     JsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,15 +52,20 @@ impl BackoffMode {
 }
 
 pub use runnable::BackgroundTask;
-pub use store::{PgTask, PgTaskStore, TaskStore};
-pub use task::{CurrentTask, NewTask, Task, TaskId, TaskState};
+pub use store::{BackgroundTaskExt, TaskStore};
+pub use task::{CurrentTask, NewTask, Task, TaskHash, TaskId, TaskState};
 pub use worker::Worker;
 pub use worker_pool::{QueueConfig, WorkerPool};
 
+#[cfg(feature = "async_postgres")]
+pub use store::PgTaskStore;
+
 mod catch_unwind;
 pub mod errors;
+#[cfg(feature = "async_postgres")]
 mod queries;
 mod runnable;
+#[cfg(feature = "async_postgres")]
 mod schema;
 mod store;
 mod task;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,115 +1,38 @@
 use crate::errors::AsyncQueueError;
-use crate::task::{NewTask, Task, TaskId, TaskState};
+use crate::task::{Task, TaskId, TaskState};
 use crate::BackgroundTask;
-use diesel::result::Error::QueryBuilderError;
-use diesel_async::scoped_futures::ScopedFutureExt;
-use diesel_async::AsyncConnection;
-use diesel_async::{pg::AsyncPgConnection, pooled_connection::bb8::Pool};
 use std::time::Duration;
 
-/// An async queue that is used to manipulate tasks, it uses PostgreSQL as storage.
-#[derive(Debug, Clone)]
-pub struct PgTaskStore {
-    pool: Pool<AsyncPgConnection>,
-}
+#[cfg(feature = "async_postgres")]
+mod pg_task_store;
 
-impl PgTaskStore {
-    pub fn new(pool: Pool<AsyncPgConnection>) -> Self {
-        PgTaskStore { pool }
-    }
-}
+#[cfg(feature = "async_postgres")]
+pub use self::pg_task_store::*;
 
-/// A trait that is used to enqueue tasks for the PostgreSQL backend.
+/// A trait that is used to enqueue tasks for a given connection type
 #[async_trait::async_trait]
-pub trait PgTask {
+pub trait BackgroundTaskExt {
     /// Enqueue a task for execution.
     ///
     /// This method accepts a connection thus enabling the user to use a transaction while
     /// scheduling tasks. This is useful if you want to schedule a task only if some other
     /// condition is met.
-    async fn enqueue(self, connection: &mut AsyncPgConnection) -> Result<(), AsyncQueueError>;
+    async fn enqueue<S: TaskStore>(
+        self,
+        connection: &mut S::Connection,
+    ) -> Result<(), AsyncQueueError>;
 }
 
 #[async_trait::async_trait]
-impl<T> PgTask for T
+impl<T> BackgroundTaskExt for T
 where
     T: BackgroundTask,
 {
-    async fn enqueue(self, connection: &mut AsyncPgConnection) -> Result<(), AsyncQueueError> {
-        let new_task = NewTask::new::<T>(self)?;
-        Task::insert(connection, new_task).await?;
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl TaskStore for PgTaskStore {
-    async fn pull_next_task(
-        &self,
-        queue_name: &str,
-        execution_timeout: Option<Duration>,
-        task_names: &[String],
-    ) -> Result<Option<Task>, AsyncQueueError> {
-        let mut connection = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| QueryBuilderError(e.into()))?;
-        connection
-            .transaction::<Option<Task>, AsyncQueueError, _>(|conn| {
-                async move {
-                    let Some(pending_task) = Task::fetch_next_pending(conn, queue_name, execution_timeout, task_names).await else {
-                        return Ok(None);
-                    };
-
-                    Task::set_running(conn, pending_task).await.map(Some)
-                }
-                .scope_boxed()
-            })
-            .await
-    }
-
-    async fn set_task_state(&self, id: TaskId, state: TaskState) -> Result<(), AsyncQueueError> {
-        let mut connection = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| QueryBuilderError(e.into()))?;
-        match state {
-            TaskState::Done => {
-                Task::set_done(&mut connection, id).await?;
-            }
-            TaskState::Failed(error_msg) => {
-                Task::fail_with_message(&mut connection, id, &error_msg).await?;
-            }
-            _ => (),
-        };
-        Ok(())
-    }
-
-    async fn remove_task(&self, id: TaskId) -> Result<u64, AsyncQueueError> {
-        let mut connection = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| QueryBuilderError(e.into()))?;
-        let result = Task::remove(&mut connection, id).await?;
-        Ok(result)
-    }
-
-    async fn schedule_task_retry(
-        &self,
-        id: TaskId,
-        backoff: Duration,
-        error: &str,
-    ) -> Result<Task, AsyncQueueError> {
-        let mut connection = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| QueryBuilderError(e.into()))?;
-        let task = Task::schedule_retry(&mut connection, id, backoff, error).await?;
-        Ok(task)
+    async fn enqueue<S: TaskStore>(
+        self,
+        connection: &mut S::Connection,
+    ) -> Result<(), AsyncQueueError> {
+        S::enqueue(connection, self).await
     }
 }
 
@@ -238,6 +161,8 @@ pub mod test_store {
 
 #[async_trait::async_trait]
 pub trait TaskStore: Send + Sync + 'static {
+    type Connection: Send;
+
     async fn pull_next_task(
         &self,
         queue_name: &str,
@@ -252,6 +177,11 @@ pub trait TaskStore: Send + Sync + 'static {
         backoff: Duration,
         error: &str,
     ) -> Result<Task, AsyncQueueError>;
+
+    async fn enqueue<T: BackgroundTask>(
+        conn: &mut Self::Connection,
+        task: T,
+    ) -> Result<(), AsyncQueueError>;
 }
 
 #[cfg(test)]

--- a/src/store/pg_task_store.rs
+++ b/src/store/pg_task_store.rs
@@ -1,0 +1,102 @@
+use diesel::result::Error::QueryBuilderError;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
+use diesel_async::{pg::AsyncPgConnection, pooled_connection::bb8::Pool};
+use std::time::Duration;
+
+use crate::errors::AsyncQueueError;
+use crate::{BackgroundTask, NewTask, Task, TaskId, TaskState, TaskStore};
+
+/// An async queue that is used to manipulate tasks, it uses PostgreSQL as storage.
+#[derive(Debug, Clone)]
+pub struct PgTaskStore {
+    pool: Pool<AsyncPgConnection>,
+}
+
+impl PgTaskStore {
+    pub fn new(pool: Pool<AsyncPgConnection>) -> Self {
+        PgTaskStore { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskStore for PgTaskStore {
+    type Connection = AsyncPgConnection;
+
+    async fn pull_next_task(
+        &self,
+        queue_name: &str,
+        execution_timeout: Option<Duration>,
+        task_names: &[String],
+    ) -> Result<Option<Task>, AsyncQueueError> {
+        let mut connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| QueryBuilderError(e.into()))?;
+        connection
+            .transaction::<Option<Task>, AsyncQueueError, _>(|conn| {
+                async move {
+                    let Some(pending_task) = Task::fetch_next_pending(conn, queue_name, execution_timeout, task_names).await else {
+                        return Ok(None);
+                    };
+
+                    Task::set_running(conn, pending_task).await.map(Some)
+                }
+                .scope_boxed()
+            })
+            .await
+    }
+
+    async fn set_task_state(&self, id: TaskId, state: TaskState) -> Result<(), AsyncQueueError> {
+        let mut connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| QueryBuilderError(e.into()))?;
+        match state {
+            TaskState::Done => {
+                Task::set_done(&mut connection, id).await?;
+            }
+            TaskState::Failed(error_msg) => {
+                Task::fail_with_message(&mut connection, id, &error_msg).await?;
+            }
+            _ => (),
+        };
+        Ok(())
+    }
+
+    async fn remove_task(&self, id: TaskId) -> Result<u64, AsyncQueueError> {
+        let mut connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| QueryBuilderError(e.into()))?;
+        let result = Task::remove(&mut connection, id).await?;
+        Ok(result)
+    }
+
+    async fn enqueue<T: BackgroundTask>(
+        connection: &mut Self::Connection,
+        task: T,
+    ) -> Result<(), AsyncQueueError> {
+        let new_task = NewTask::new(task)?;
+        Task::insert(connection, new_task).await?;
+        Ok(())
+    }
+
+    async fn schedule_task_retry(
+        &self,
+        id: TaskId,
+        backoff: Duration,
+        error: &str,
+    ) -> Result<Task, AsyncQueueError> {
+        let mut connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| QueryBuilderError(e.into()))?;
+        let task = Task::schedule_retry(&mut connection, id, backoff, error).await?;
+        Ok(task)
+    }
+}


### PR DESCRIPTION
This makes it possible to provide custom implementations of `TaskStore` outside of backie (for example for sync diesel connections and other backend types)

I've put everything diesel_async specific behind a feature flag that is enabled by default. The public API with that feature flag enabled stays mostly the same as demonstrated by the example. Only the `enqueue` function now needs to know about a specific task store to determine the backend type.

My use case for this is using backie with other diesel connections as well